### PR TITLE
Fix docs typo

### DIFF
--- a/docs/en/docs/getting-started.md
+++ b/docs/en/docs/getting-started.md
@@ -51,8 +51,8 @@ And render the data with `render_once()` method.
 ```rust
 fn main() {
     let ctx = HelloTemplate {
-        messages: vec![String::from("foo"), String::from("bar")];
-    }
+        messages: vec![String::from("foo"), String::from("bar")],
+    };
 
     // Now render templates with given data
     println!("{}", ctx.render_once().unwrap());


### PR DESCRIPTION
Thanks for working on sailfish!

This just fixes a small typo in the getting started docs.