### PR TITLE
Use std::result::Result in derive macro to allow custom Result types

### DIFF
--- a/sailfish-compiler/src/procmacro.rs
+++ b/sailfish-compiler/src/procmacro.rs
@@ -267,7 +267,7 @@ fn derive_template_impl(tokens: TokenStream) -> Result<TokenStream, syn::Error> 
 
     let tokens = quote! {
         impl #impl_generics sailfish::TemplateOnce for #name #ty_generics #where_clause {
-            fn render_once_to_string(self, buf: &mut String) -> Result<(), sailfish::runtime::RenderError> {
+            fn render_once_to_string(self, buf: &mut String) -> std::result::Result<(), sailfish::runtime::RenderError> {
                 #include_bytes_seq;
 
                 use sailfish::runtime as __sf_rt;


### PR DESCRIPTION
When using a custom `Result` type, the `TemplateOnce` derive macro fails with error: 
```
wrong number of type arguments: expected 1, found 2
```

A custom `Result` when you have a project-wide `Error` type:

```rust
type Result<T> = std::result::Result<T, Error>;
```

Allows to omit the `E` type from `Result<T, E>` in e.g function definitions: `fn func() -> Result<String>`