### PR TITLE
Bump yaml-rust version

### DIFF
--- a/sailfish-compiler/Cargo.toml
+++ b/sailfish-compiler/Cargo.toml
@@ -24,7 +24,7 @@ config = ["yaml-rust"]
 [dependencies]
 memchr = "2.3.3"
 quote = { version = "1.0.6", default-features = false }
-yaml-rust = { version = "0.4.4", optional = true }
+yaml-rust = { version = "0.4.5", optional = true }
 home = "0.5.3"
 
 [dependencies.syn]


### PR DESCRIPTION
Closes #38

`yaml-rust` and its dep `linked-hash-map` (with your PR merged) has been updated. This solves the immediate issue in #38 but I'm still commited to creating a PR migrating from YAML to TOML when I get more time for it, see [my comment](https://github.com/Kogia-sima/sailfish/issues/41#issuecomment-757521691) for why and when that will be.