### PR TITLE
Workaround for incorrect cargo fingerprints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "ctor"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +36,18 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "filetime"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
 
 [[package]]
 name = "glob"
@@ -69,6 +93,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "linked-hash-map"
@@ -122,6 +152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +182,7 @@ dependencies = [
 name = "sailfish-compiler"
 version = "0.3.0"
 dependencies = [
+ "filetime",
  "home",
  "memchr",
  "pretty_assertions",

--- a/sailfish-compiler/Cargo.toml
+++ b/sailfish-compiler/Cargo.toml
@@ -26,6 +26,7 @@ memchr = "2.3.3"
 quote = { version = "1.0.6", default-features = false }
 yaml-rust = { version = "0.4.4", optional = true }
 home = "0.5.3"
+filetime = "0.2.14"
 
 [dependencies.syn]
 version = "1.0.21"

--- a/sailfish-compiler/src/compiler.rs
+++ b/sailfish-compiler/src/compiler.rs
@@ -11,7 +11,7 @@ use crate::optimizer::Optimizer;
 use crate::parser::Parser;
 use crate::resolver::Resolver;
 use crate::translator::{TranslatedSource, Translator};
-use crate::util::{read_to_string, rustfmt_block};
+use crate::util::{copy_filetimes, read_to_string, rustfmt_block};
 
 #[derive(Default)]
 pub struct Compiler {
@@ -81,6 +81,12 @@ impl Compiler {
                 .chain_err(|| format!("Failed to create artifact: {:?}", output))?;
             writeln!(f, "{}", rustfmt_block(&*string).unwrap_or(string))
                 .chain_err(|| format!("Failed to write artifact into {:?}", output))?;
+            drop(f);
+
+            // FIXME: This is a silly hack to prevent output file from being tracking by
+            // cargo. Another better solution should be considered.
+            let _ = copy_filetimes(input, output);
+
             Ok(report)
         };
 

--- a/sailfish-compiler/src/util.rs
+++ b/sailfish-compiler/src/util.rs
@@ -1,3 +1,4 @@
+use filetime::FileTime;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -75,4 +76,12 @@ pub fn rustfmt_block(source: &str) -> io::Result<String> {
             "rustfmt command failed",
         ))
     }
+}
+
+pub fn copy_filetimes(input: &Path, output: &Path) -> io::Result<()> {
+    let mtime = fs::metadata(input)
+        .and_then(|metadata| metadata.modified())
+        .map_or(FileTime::zero(), |time| FileTime::from_system_time(time));
+
+    filetime::set_file_times(output, mtime, mtime)
 }


### PR DESCRIPTION
fix #46

sailfish generates temporary artifact and call `std::include!` macro for it in order to generate human-readable error message. However, `std::include` macro appends input file to dep-info, which `cargo` decides whether recompilation is needed based off. Since `cargo` generates timestamp **before** compilation, the mtime of generated artifacts is always later than `cargo`'s timestamp. That's why cargo always recompile project.

In this workaround `sailfish-compiler` copy mtime from input templates to generated files. Note that this workaround depends on `cargo`'s internal implementation and may stop working in the future. Another better option should be considered.