### PR TITLE
Update dependency on proc-macro2

### DIFF
--- a/sailfish-compiler/Cargo.toml
+++ b/sailfish-compiler/Cargo.toml
@@ -34,7 +34,7 @@ default-features = false
 features = ["parsing", "full", "visit-mut", "printing"]
 
 [dependencies.proc-macro2]
-version = ">=1.0.11, <=1.0.26"
+version = ">=1.0.11, <=1.0.27"
 default-features = false
 features = ["span-locations"]
 


### PR DESCRIPTION
Allow the latest version of `proc-macro2`.

I'm not sure the update breaks anything, however.